### PR TITLE
UI - tied form labels to elements

### DIFF
--- a/src/assets/scss/sealog.scss
+++ b/src/assets/scss/sealog.scss
@@ -114,6 +114,10 @@
   }
 }
 
+.legend {
+  font-size: .9rem;
+}
+
 // react-datetime styles
 @import "~react-datetime/css/react-datetime.css";
 

--- a/src/components/event_comment_modal.js
+++ b/src/components/event_comment_modal.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import { Button, Form, Modal } from 'react-bootstrap';
@@ -10,7 +10,6 @@ class EventCommentModal extends Component {
 
   constructor (props) {
     super(props);
-
     this.handleFormSubmit = this.handleFormSubmit.bind(this);
   }
 
@@ -30,44 +29,44 @@ class EventCommentModal extends Component {
     }
   }
 
-  componentWillUnmount() {
-  }
+  componentWillUnmount() {}
 
-  async populateDefaultValues() {
-    const event_option_comment = (this.props.event) ? this.props.event.event_options.find(event_option => event_option.event_option_name === 'event_comment') : null;
+  populateDefaultValues() {
+    const { event, initialize } = this.props;
+    const event_option_comment = event ? event.event_options.find(event_option => event_option.event_option_name === 'event_comment') : null;
     if (event_option_comment) {
-      this.props.initialize({ 'event_comment': event_option_comment.event_option_value });
+      initialize({ 'event_comment': event_option_comment.event_option_value });
     }
   }
 
 
   handleFormSubmit(formProps) {
 
+    const { event, handleUpdateEvent, handleHide } = this.props;
     let existing_comment = false;
-    let event_options = this.props.event.event_options = this.props.event.event_options.map(event_option => {
-      if(event_option.event_option_name === 'event_comment') {
+    let event_options = (event && event.event_options) ? event.event_options.map(event_option => {
+      if (event_option.event_option_name === 'event_comment') {
         existing_comment = true;
         return { event_option_name: 'event_comment', event_option_value: formProps.event_comment}
       } else {
         return event_option
       }
-    })
+    }) : [];
 
     if(!existing_comment) {
       event_options.push({ event_option_name: 'event_comment', event_option_value: formProps.event_comment})
     }
 
-    this.props.handleUpdateEvent(this.props.event.id, this.props.event.event_value, this.props.event.event_free_text, event_options, this.props.event.ts);
-    this.props.handleHide();
+    handleUpdateEvent(event.id, event.event_value, event.event_free_text, event_options, event.ts);
+    handleHide();
   }
 
   render() {
     const { show, handleHide, handleSubmit, submitting, valid, event } = this.props
 
-    if (event) {
       return (
-        <Modal show={show} onHide={handleHide}>
-          <Form onSubmit={ handleSubmit(this.handleFormSubmit.bind(this)) }>
+        <Modal show={show} onHide={handleHide} onEntered={() => document.getElementById('event_comment').focus()}>
+          <Form onSubmit={handleSubmit(this.handleFormSubmit)}>
             <Modal.Header closeButton>
               <Modal.Title>Add/Update Comment</Modal.Title>
             </Modal.Header>
@@ -76,6 +75,7 @@ class EventCommentModal extends Component {
               <Field
                 name="event_comment"
                 component={renderTextArea}
+                id="event_comment"
               />
             </Modal.Body>
 
@@ -86,10 +86,6 @@ class EventCommentModal extends Component {
           </Form>
         </Modal>
       );
-    }
-    else {
-      return null;
-    }
   }
 }
 

--- a/src/components/event_history.js
+++ b/src/components/event_history.js
@@ -217,7 +217,7 @@ class EventHistory extends Component {
             { Label }
             <Form inline className="float-right">
               {NewEventToggle}
-              <FormControl size="sm" type="text" placeholder="Filter" className="mr-sm-2" onKeyPress={this.handleKeyDown} onChange={this.handleSearchChange}/>
+              <FormControl size="sm" type="text" name="Filter" placeholder="Filter" className="mr-sm-2" onKeyPress={this.handleKeyDown} onChange={this.handleSearchChange}/>
               <OverlayTrigger placement="top" overlay={compressTooltip}><span className="mr-2" variant="secondary" size="sm" onClick={ () => this.handleHideEventHistoryFullscreen() }><FontAwesomeIcon icon='compress' fixedWidth/></span></OverlayTrigger>{' '}
               <OverlayTrigger placement="top" overlay={hideTooltip}><span variant="secondary" size="sm" onClick={ () => this.handleHideEventHistory() }><FontAwesomeIcon icon='eye-slash' fixedWidth/></span></OverlayTrigger>
             </Form>
@@ -230,7 +230,7 @@ class EventHistory extends Component {
           { Label }
           <Form inline className="float-right">
             {NewEventToggle}
-            <FormControl size="sm" type="text" placeholder="Filter" className="mr-sm-2" onKeyPress={this.handleKeyDown} onChange={this.handleSearchChange}/>
+            <FormControl size="sm" type="text" name="Filter" placeholder="Filter" className="mr-sm-2" onKeyPress={this.handleKeyDown} onChange={this.handleSearchChange}/>
             <OverlayTrigger placement="top" overlay={expandTooltip}><span className="mr-2" variant="secondary" size="sm" onClick={ () => this.handleShowEventHistoryFullscreen() }><FontAwesomeIcon icon='compress' fixedWidth/></span></OverlayTrigger>{' '}
             <OverlayTrigger placement="top" overlay={hideTooltip}><span variant="secondary" size="sm" onClick={ () => this.handleHideEventHistory() }><FontAwesomeIcon icon='eye-slash' fixedWidth/></span></OverlayTrigger>
           </Form>

--- a/src/components/form_elements.js
+++ b/src/components/form_elements.js
@@ -8,24 +8,24 @@ export const timeFormat = "HH:mm:ss";
 
 export function renderStaticTextField({ input, label, xs=12, sm=6, md=12, lg=6}) {
   
-  const labelComponent = (label)? <Form.Label>{label}</Form.Label> : null;
+  const labelComponent = (label)? <Form.Label htmlFor={input.name}>{label}</Form.Label> : null;
 
   return (
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
       {labelComponent}
-      <Form.Control type="text" {...input} disabled />
+      <Form.Control type="text" {...input} disabled id={input.name} />
     </Form.Group>
   );
 }
 
 export function renderTextField({ input, label, placeholder, required, meta: { touched, error, warning }, type="text", disabled=false, xs=12, sm=6, md=12, lg=6}) {
   const requiredField = (required)? <span className='text-danger'> *</span> : '';
-  const labelComponent = (label)? <Form.Label>{label}{requiredField}</Form.Label> : null;
+  const labelComponent = (label)? <Form.Label htmlFor={input.name}>{label}{requiredField}</Form.Label> : null;
 
   return (
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
       {labelComponent}
-      <Form.Control type={type} {...input} placeholder={placeholder} isInvalid={touched && (warning || error)} disabled={disabled} />
+      <Form.Control type={type} {...input} placeholder={placeholder} isInvalid={touched && (warning || error)} disabled={disabled} id={input.name} />
       <Form.Control.Feedback className={(warning) ? 'text-warning': ''} type="invalid">{error}{warning}</Form.Control.Feedback>
     </Form.Group>
   );
@@ -36,8 +36,8 @@ export function renderTextArea({ input, label, placeholder, required, meta: { to
 
   return (
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
-      <Form.Label>{label}{requiredField}</Form.Label>
-      <Form.Control as="textarea" {...input} placeholder={placeholder} isInvalid={touched && error} disabled={disabled} rows={rows}/>
+      <Form.Label htmlFor={input.name}>{label}{requiredField}</Form.Label>
+      <Form.Control as="textarea" {...input} placeholder={placeholder} isInvalid={touched && error} disabled={disabled} rows={rows} id={input.name} ref={input.ref} />
       <Form.Control.Feedback type="invalid">{error}</Form.Control.Feedback>
     </Form.Group>
   );
@@ -55,7 +55,7 @@ export function renderSelectField({ input, label, placeholder, required, options
 
   return (
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
-      <Form.Label>{label}{requiredField}</Form.Label>
+      <Form.Label htmlFor={input.name}>{label}{requiredField}</Form.Label>
       <Form.Control as="select" {...input} placeholder={placeholder} isInvalid={touched && error} disabled={disabled} >
         { defaultOption }
         { optionList }
@@ -69,12 +69,13 @@ export function renderDatePicker({ input, label, required, meta: { touched, erro
   let requiredField = (required)? <span className='text-danger'> *</span> : '';
   
   const inputProps = {
-    disabled: disabled
+    disabled: disabled,
+    id: input.name
   } 
 
   return (
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
-      <Form.Label>{label}{requiredField}</Form.Label>
+      <Form.Label htmlFor={input.name}>{label}{requiredField}</Form.Label>
       <Datetime className="rdtPicker-sealog" {...input} utc={true} value={input.value ? moment.utc(input.value).format(dateFormat) : null} dateFormat={dateFormat} timeFormat={false} selected={input.value ? moment.utc(input.value, dateFormat) : null } inputProps={inputProps} />
       {touched && (error && <div className={"w-100 mt-1 text-danger"} style={{fontSize: ".7rem"}}>{error}</div>)}
     </Form.Group>
@@ -85,12 +86,13 @@ export function renderDateTimePicker({ input, label, required, meta: { touched, 
   let requiredField = (required)? <span className='text-danger'> *</span> : ''
 
   const inputProps = {
-    disabled: disabled
+    disabled: disabled,
+    id: input.name
   } 
 
   return (
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
-      <Form.Label>{label}{requiredField}</Form.Label>
+      <Form.Label htmlFor={input.name}>{label}{requiredField}</Form.Label>
       <Datetime className="rdtPicker-sealog" {...input} utc={true} value={input.value ? moment.utc(input.value).format(dateFormat + ' ' + timeFormat) : null} dateFormat={dateFormat} timeFormat={timeFormat} selected={input.value ? moment.utc(input.value) : null } inputProps={inputProps} />
       {touched && (error && <div className={"w-100 mt-1 text-danger"} style={{fontSize: ".7rem"}}>{error}</div>)}
     </Form.Group>
@@ -101,13 +103,14 @@ export function renderCheckboxGroup({ label, options, input, required, meta: { d
 
   const requiredField = (required)? (<span className='text-danger'> *</span>) : '';
   const checkboxList = options.map((option, index) => {
+    const tooltip = (option.description)? (<Tooltip id={`${input.name}_${option.value}_Tooltip`}>{option.description}</Tooltip>) : null;
 
-    const tooltip = (option.description)? (<Tooltip id={`${option.value}_Tooltip`}>{option.description}</Tooltip>) : null
     
     const checkbox = <Form.Check
       label={(indication && input.value.includes(option.value)) ? <span className="text-warning">{option.value}</span> : option.value }
-      name={`${option.label}[${index}]`}
-      key={`${label}.${index}`}
+      name={`${input.name}[${index}]`}
+      id={`${input.name}_${option.value}`}
+      key={`${input.name}_${option.value}`}
       value={option.value}
       checked={input.value.indexOf(option.value) !== -1}
       disabled={disabled}
@@ -123,13 +126,15 @@ export function renderCheckboxGroup({ label, options, input, required, meta: { d
       }}
     />
 
-    return (tooltip) ? <span key={`${label}.${index}`}><OverlayTrigger placement="right" overlay={tooltip}>{checkbox}</OverlayTrigger></span> : <span key={`${label}.${index}`}>{checkbox}</span>;
+    return (tooltip) ? <span key={`${input.name}_${option.value}_span`}><OverlayTrigger placement="right" overlay={tooltip}>{checkbox}</OverlayTrigger></span> : <span key={`${input.name}_${option.value}_span`}>{checkbox}</span>;
   });
 
   return (
     <Form.Group as={Col}>
-      <Form.Label><span>{label}{requiredField}</span> {dirty && (error && <span className="text-danger" style={{fontSize: ".7rem"}}>{error}<br/></span>)}</Form.Label><br/>
-      {checkboxList}
+      <fieldset>
+        <legend><span>{label}{requiredField}</span> {dirty && (error && <span className="text-danger" style={{fontSize: ".7rem"}}>{error}<br/></span>)}</legend>
+        {checkboxList}
+      </fieldset>
     </Form.Group>      
   );
 }
@@ -139,6 +144,7 @@ export function renderCheckbox({ input, label, meta: { dirty, error }, disabled=
     <Form.Group as={Col} xs={xs} sm={sm} md={md} lg={lg}>
       <Form.Check
         {...input}
+        id={`${input.name}`}
         label={label}
         checked={input.value ? true : false}
         onChange={(e) => input.onChange(e.target.checked)}
@@ -155,15 +161,15 @@ export function renderCheckbox({ input, label, meta: { dirty, error }, disabled=
 export function renderRadioGroup({ label, options, input, required, meta: { dirty, error }, disabled=false, inline=false, indication=false }) {
 
   const requiredField = (required)? (<span className='text-danger'> *</span>) : '';
-  // console.log(options);
   const radioList = options.map((option, index) => {
+    const tooltip = (option.description)? (<Tooltip id={`${input.name}_${option.value}_Tooltip`}>{option.description}</Tooltip>) : null;
 
-    const tooltip = (option.description)? (<Tooltip id={`${option.value}_Tooltip`}>{option.description}</Tooltip>) : null
     
     const radio = <Form.Check
       label={(indication && input.value === option.value) ? <span className="text-warning">{option.value}</span> : option.value }
-      name={`${label}`}
-      key={`${label}.${index}`}
+      name={`${input.name}`}
+      id={`${input.name}_${option.value}`}
+      key={`${input.name}_${option.value}`}
       value={option.value}
       checked={input.value === option.value}
       disabled={disabled}
@@ -174,13 +180,15 @@ export function renderRadioGroup({ label, options, input, required, meta: { dirt
       }}
     />
 
-    return (tooltip) ? <span key={`${label}.${index}`}><OverlayTrigger placement="right" overlay={tooltip}>{radio}</OverlayTrigger></span> : <span key={`${label}.${index}`}>{radio}</span>;
+    return (tooltip) ? <span key={`${input.name}_${option.value}_span`}><OverlayTrigger placement="right" overlay={tooltip}>{radio}</OverlayTrigger></span> : <span key={`${input.name}_${option.value}_span`}>{radio}</span>;
   });
 
   return (
     <Form.Group as={Col}>
-      <Form.Label><span>{label}{requiredField}</span> {dirty && (error && <span className="text-danger" style={{fontSize: ".7rem"}}>{error}<br/></span>)}</Form.Label><br/>
-      {radioList}
+      <fieldset>
+        <legend><span>{label}{requiredField}</span> {dirty && (error && <span className="text-danger" style={{fontSize: ".7rem"}}>{error}<br/></span>)}</legend>
+        {radioList}
+      </fieldset>
     </Form.Group>      
   );
 }
@@ -224,3 +232,4 @@ export function renderMessage(message) {
     );
   }
 }
+


### PR DESCRIPTION
This changes the generation of almost every form, changes shouldn't break anything but are prime suspects for production bugs, review would be useful.

- This fixes radio button and checkbox labels not being clickable and gets rid of console errors
- This fixes Add Comment modal focus - now can type after click
- Added htmlFor and id elements to tie fields to labels
- Fn populateDefaultValues had no async content - became synchronous